### PR TITLE
fix(mvc-1): TODO 파일명을 의도에 맞게 수정

### DIFF
--- a/spring-mvc-1/initial/src/main/java/cholog/MemberController.java
+++ b/spring-mvc-1/initial/src/main/java/cholog/MemberController.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Controller;
 public class MemberController {
 
     public String world() {
-        // TODO: /hello 요청 시 resources/templates/static.html 페이지가 응답할 수 있도록 설정하세요.
+        // TODO: /hello 요청 시 resources/templates/hello.html 페이지가 응답할 수 있도록 설정하세요.
         // TODO: 쿼리 파라미터로 name 요청이 들어왔을 때 해당 값을 hello.html에서 사용할 수 있도록 하세요.
         return null;
     }


### PR DESCRIPTION
`static.html`은 이전(2. Static Page)에 활용해 template을 활용하는 예제 테스트의 의도와 달라 보입니다. 아래 *수행 방법*에도 `hello.html`을 활용하라고 명시돼 있어 이를 수정했습니다.