### PR TITLE
style(mvc-2, jdbc-1): 클래스명을 컨벤션에 맞게 수정

### DIFF
--- a/spring-jdbc-1/complete/src/main/java/cholog/QueryingDao.java
+++ b/spring-jdbc-1/complete/src/main/java/cholog/QueryingDao.java
@@ -7,10 +7,10 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public class QueryingDAO {
+public class QueryingDao {
     private JdbcTemplate jdbcTemplate;
 
-    public QueryingDAO(JdbcTemplate jdbcTemplate) {
+    public QueryingDao(JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
     }
 

--- a/spring-jdbc-1/complete/src/main/java/cholog/UpdatingDao.java
+++ b/spring-jdbc-1/complete/src/main/java/cholog/UpdatingDao.java
@@ -9,10 +9,10 @@ import org.springframework.stereotype.Repository;
 import java.sql.PreparedStatement;
 
 @Repository
-public class UpdatingDAO {
+public class UpdatingDao {
     private JdbcTemplate jdbcTemplate;
 
-    public UpdatingDAO(JdbcTemplate jdbcTemplate) {
+    public UpdatingDao(JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
     }
 

--- a/spring-jdbc-1/complete/src/test/java/cholog/QueryingDaoTest.java
+++ b/spring-jdbc-1/complete/src/test/java/cholog/QueryingDaoTest.java
@@ -14,14 +14,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @JdbcTest
 public class QueryingDaoTest {
-    private QueryingDAO queryingDAO;
+    private QueryingDao queryingDao;
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
     @BeforeEach
     void setUp() {
-        queryingDAO = new QueryingDAO(jdbcTemplate);
+        queryingDao = new QueryingDao(jdbcTemplate);
 
         jdbcTemplate.execute("DROP TABLE customers IF EXISTS");
         jdbcTemplate.execute("CREATE TABLE customers(" +
@@ -36,21 +36,21 @@ public class QueryingDaoTest {
 
     @Test
     void count() {
-        int count = queryingDAO.count();
+        int count = queryingDao.count();
 
         assertThat(count).isEqualTo(4);
     }
 
     @Test
     void getLastName() {
-        String lastName = queryingDAO.getLastName(1L);
+        String lastName = queryingDao.getLastName(1L);
 
         assertThat(lastName).isEqualTo("Woo");
     }
 
     @Test
     void findCustomerById() {
-        Customer customer = queryingDAO.findCustomerById(1L);
+        Customer customer = queryingDao.findCustomerById(1L);
 
         assertThat(customer).isNotNull();
         assertThat(customer.getLastName()).isEqualTo("Woo");
@@ -58,14 +58,14 @@ public class QueryingDaoTest {
 
     @Test
     void findAllCustomers() {
-        List<Customer> customers = queryingDAO.findAllCustomers();
+        List<Customer> customers = queryingDao.findAllCustomers();
 
         assertThat(customers).hasSize(4);
     }
 
     @Test
     void findCustomerByFirstName() {
-        List<Customer> customers = queryingDAO.findCustomerByFirstName("Josh");
+        List<Customer> customers = queryingDao.findCustomerByFirstName("Josh");
 
         assertThat(customers).hasSize(2);
     }

--- a/spring-jdbc-1/complete/src/test/java/cholog/UpdatingDaoTest.java
+++ b/spring-jdbc-1/complete/src/test/java/cholog/UpdatingDaoTest.java
@@ -15,16 +15,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @JdbcTest
 public class UpdatingDaoTest {
-    private UpdatingDAO updatingDAO;
-    private QueryingDAO queryingDAO;
+    private UpdatingDao updatingDao;
+    private QueryingDao queryingDao;
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
     @BeforeEach
     void setUp() {
-        queryingDAO = new QueryingDAO(jdbcTemplate);
-        updatingDAO = new UpdatingDAO(jdbcTemplate);
+        queryingDao = new QueryingDao(jdbcTemplate);
+        updatingDao = new UpdatingDao(jdbcTemplate);
 
         jdbcTemplate.execute("DROP TABLE customers IF EXISTS");
         jdbcTemplate.execute("CREATE TABLE customers(" +
@@ -40,16 +40,16 @@ public class UpdatingDaoTest {
     @Test
     void insert() {
         Customer customer = new Customer("Leonor", "Watling");
-        updatingDAO.insert(customer);
+        updatingDao.insert(customer);
 
-        List<Customer> customers = queryingDAO.findCustomerByFirstName("Leonor");
+        List<Customer> customers = queryingDao.findCustomerByFirstName("Leonor");
 
         assertThat(customers).hasSize(1);
     }
 
     @Test
     void delete() {
-        int rowNum = updatingDAO.delete(1L);
+        int rowNum = updatingDao.delete(1L);
 
         assertThat(rowNum).isEqualTo(1);
     }
@@ -57,7 +57,7 @@ public class UpdatingDaoTest {
     @Test
     void keyHolder() {
         Customer customer = new Customer("Leonor", "Watling");
-        Long id = updatingDAO.insertWithKeyHolder(customer);
+        Long id = updatingDao.insertWithKeyHolder(customer);
 
         assertThat(id).isNotNull();
     }

--- a/spring-jdbc-1/initial/src/main/java/cholog/QueryingDao.java
+++ b/spring-jdbc-1/initial/src/main/java/cholog/QueryingDao.java
@@ -7,10 +7,10 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public class QueryingDAO {
+public class QueryingDao {
     private JdbcTemplate jdbcTemplate;
 
-    public QueryingDAO(JdbcTemplate jdbcTemplate) {
+    public QueryingDao(JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
     }
 

--- a/spring-jdbc-1/initial/src/main/java/cholog/UpdatingDao.java
+++ b/spring-jdbc-1/initial/src/main/java/cholog/UpdatingDao.java
@@ -9,10 +9,10 @@ import org.springframework.stereotype.Repository;
 import java.sql.PreparedStatement;
 
 @Repository
-public class UpdatingDAO {
+public class UpdatingDao {
     private JdbcTemplate jdbcTemplate;
 
-    public UpdatingDAO(JdbcTemplate jdbcTemplate) {
+    public UpdatingDao(JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
     }
 

--- a/spring-jdbc-1/initial/src/test/java/cholog/QueryingDaoTest.java
+++ b/spring-jdbc-1/initial/src/test/java/cholog/QueryingDaoTest.java
@@ -14,14 +14,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @JdbcTest
 public class QueryingDaoTest {
-    private QueryingDAO queryingDAO;
+    private QueryingDao queryingDao;
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
     @BeforeEach
     void setUp() {
-        queryingDAO = new QueryingDAO(jdbcTemplate);
+        queryingDao = new QueryingDao(jdbcTemplate);
 
         jdbcTemplate.execute("DROP TABLE customers IF EXISTS");
         jdbcTemplate.execute("CREATE TABLE customers(" +
@@ -37,21 +37,21 @@ public class QueryingDaoTest {
 
     @Test
     void count() {
-        int count = queryingDAO.count();
+        int count = queryingDao.count();
 
         assertThat(count).isEqualTo(4);
     }
 
     @Test
     void getLastName() {
-        String lastName = queryingDAO.getLastName(1L);
+        String lastName = queryingDao.getLastName(1L);
 
         assertThat(lastName).isEqualTo("Woo");
     }
 
     @Test
     void findCustomerById() {
-        Customer customer = queryingDAO.findCustomerById(1L);
+        Customer customer = queryingDao.findCustomerById(1L);
 
         assertThat(customer).isNotNull();
         assertThat(customer.getLastName()).isEqualTo("Woo");
@@ -59,14 +59,14 @@ public class QueryingDaoTest {
 
     @Test
     void findAllCustomers() {
-        List<Customer> customers = queryingDAO.findAllCustomers();
+        List<Customer> customers = queryingDao.findAllCustomers();
 
         assertThat(customers).hasSize(4);
     }
 
     @Test
     void findCustomerByFirstName() {
-        List<Customer> customers = queryingDAO.findCustomerByFirstName("Josh");
+        List<Customer> customers = queryingDao.findCustomerByFirstName("Josh");
 
         assertThat(customers).hasSize(2);
     }

--- a/spring-jdbc-1/initial/src/test/java/cholog/UpdatingDaoTest.java
+++ b/spring-jdbc-1/initial/src/test/java/cholog/UpdatingDaoTest.java
@@ -15,16 +15,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @JdbcTest
 public class UpdatingDaoTest {
-    private UpdatingDAO updatingDAO;
-    private QueryingDAO queryingDAO;
+    private UpdatingDao updatingDao;
+    private QueryingDao queryingDao;
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
     @BeforeEach
     void setUp() {
-        queryingDAO = new QueryingDAO(jdbcTemplate);
-        updatingDAO = new UpdatingDAO(jdbcTemplate);
+        queryingDao = new QueryingDao(jdbcTemplate);
+        updatingDao = new UpdatingDao(jdbcTemplate);
 
         jdbcTemplate.execute("DROP TABLE customers IF EXISTS");
         jdbcTemplate.execute("CREATE TABLE customers(" +
@@ -40,16 +40,16 @@ public class UpdatingDaoTest {
     @Test
     void insert() {
         Customer customer = new Customer("Leonor", "Watling");
-        updatingDAO.insert(customer);
+        updatingDao.insert(customer);
 
-        List<Customer> customers = queryingDAO.findCustomerByFirstName("Leonor");
+        List<Customer> customers = queryingDao.findCustomerByFirstName("Leonor");
 
         assertThat(customers).hasSize(1);
     }
 
     @Test
     void delete() {
-        int rowNum = updatingDAO.delete(1L);
+        int rowNum = updatingDao.delete(1L);
 
         assertThat(rowNum).isEqualTo(1);
     }
@@ -57,7 +57,7 @@ public class UpdatingDaoTest {
     @Test
     void keyHolder() {
         Customer customer = new Customer("Leonor", "Watling");
-        Long id = updatingDAO.insertWithKeyHolder(customer);
+        Long id = updatingDao.insertWithKeyHolder(customer);
 
         assertThat(id).isNotNull();
     }

--- a/spring-mvc-2/complete/src/test/java/cholog/CrudTest.java
+++ b/spring-mvc-2/complete/src/test/java/cholog/CrudTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
-class CRUDTest {
+class CrudTest {
     @Test
     void create() {
         var response = RestAssured

--- a/spring-mvc-2/initial/src/test/java/cholog/CrudTest.java
+++ b/spring-mvc-2/initial/src/test/java/cholog/CrudTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
-class CRUDTest {
+class CrudTest {
     @Test
     void create() {
         var response = RestAssured


### PR DESCRIPTION
`DAO` -> `Dao`
`CRUD` -> `Crud`

비즈니스 클래스에선 DAO로 사용하고 테스트 코드에선 Dao로 사용하고 있어 이를 통일해주었습니다. 