### PR TITLE
test(jpa): save() 테스트가 통과되도록 코드 수정

### DIFF
--- a/spring-data-jpa-1/complete/src/test/java/cholog/RepositoryTest.java
+++ b/spring-data-jpa-1/complete/src/test/java/cholog/RepositoryTest.java
@@ -20,6 +20,7 @@ public class RepositoryTest {
     @Test
     void save() {
         customerRepository.save(new Customer("Jack", "Bauer"));
+        customerRepository.save(new Customer("Chloe", "O'Brian"));
 
         Iterable<Customer> customers = customerRepository.findAll();
         assertThat(customers).extracting(Customer::getFirstName).containsOnly("Jack", "Chloe");


### PR DESCRIPTION
complete 내부에 있는 테스트는 모두 성공하는 테스트여야 하는 것으로 알고 있습니다.
다만, `spring-data-jpa-1/complete` 내부에 있는 RepositoryTest에서 `save()` 테스트가 실패하는 것을 발견했고, 이유를 찾아보니 검증부에서 존재하지 않는 값을 검증하고 있었습니다.

따라서, 

### Before
```java
@Test
void save() {
    customerRepository.save(new Customer("Jack", "Bauer"));

    Iterable<Customer> customers = customerRepository.findAll();
    assertThat(customers).extracting(Customer::getFirstName).containsOnly("Jack", "Chloe");
}
```
### After
```java
@Test
void save() {
    customerRepository.save(new Customer("Jack", "Bauer"));
    customerRepository.save(new Customer("Chloe", "O'Brian")); // 기존 검증부에 맞춰서 save를 추가적으로 해주었습니다.

    Iterable<Customer> customers = customerRepository.findAll();
    assertThat(customers).extracting(Customer::getFirstName).containsOnly("Jack", "Chloe");
}
```

위와 같이 테스트가 성공되도록 코드 한줄을 추가했습니다!